### PR TITLE
sync remove git hooks

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,0 @@
-#!/usr/bin/env sh
-. "$(dirname -- "$0")/_/husky.sh"
-
-npx prettier . -w
-git add .

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,7 +14,7 @@
   // Specify file types.
   "files.associations": {"pre-commit": "shellscript"},
 
-  // Prettier default formatter.
+  // Prettier default formatter and auto format on save.
   "editor.formatOnSave": true,
   "editor.codeActionsOnSave": {"source.organizeImports": true},
   "editor.defaultFormatter": "esbenp.prettier-vscode",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -27,6 +27,7 @@
     "deutsch",
     "enummember",
     "hilltwice",
+    "tamasfe",
     "vitest",
     "vsix",
     "русский",

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -4,7 +4,8 @@
 2. Use ascii characters in commit message for not all terminal are utf8.
 3. Name your branch as your user name (also ascii).
 4. Pull request to the `dev` branch rather than the `main` branch.
-5. Anyone who had contributed to this project are welcomed to add their names
+5. Title of PRs on GitHub should be lowercased.
+6. Anyone who had contributed to this project are welcomed to add their names
    in the [Author's List](./authors.txt)
 
 ## About locales and translations

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "commands": []
   },
   "scripts": {
-    "prepare": "husky install",
     "package": "npm run build && cd extension && vsce package && cd ..",
     "prettier": "prettier . -w",
     "build": "npm run rollup && node scripts/build.js",
@@ -47,7 +46,6 @@
     "@types/node": "^20.8.9",
     "@types/vscode": "^1.83.1",
     "@vscode/vsce": "^2.22.0",
-    "husky": "^8.0.3",
     "prettier": "^3.0.3",
     "rollup": "^4.1.5",
     "tslib": "^2.6.2",

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,9 @@ Supported languages and file types:
 |    Json     |  ✔️  |  ✔️   |            build-in             |
 |  Markdown   |  ✔️  |  ✔️   |            build-in             |
 | Properties  |  ✔️  |  ✔️   |            build-in             |
+|    Rust     |  ✔️  |  ❌   |    `rust-lang.rust-analyzer`    |
 | ShellScript |  ❌  |  ✔️   | `mads-hartmann.bash-ide-vscode` |
+|    Toml     |  ✔️  |  ❌   |   `tamasfe.even-better-toml`    |
 | TypeScript  |  ✔️  |  ❌   |            build-in             |
 |    Yaml     |  ✔️  |  ✔️   |      `redhat.vscode-yaml`       |
 

--- a/themes/dark-color-theme.json
+++ b/themes/dark-color-theme.json
@@ -169,6 +169,7 @@
         "foreground": "#fbd640"
       }
     },
+
     {
       "scope": ["markup.bold"],
       "settings": {
@@ -236,6 +237,13 @@
       "scope": ["variable.other.constant"],
       "settings": {
         "foreground": "#94b6c6",
+        "fontStyle": ""
+      }
+    },
+    {
+      "scope": ["support.type.property-name.table.toml"],
+      "settings": {
+        "foreground": "#34ade6",
         "fontStyle": ""
       }
     },

--- a/themes/dark-color-theme.json
+++ b/themes/dark-color-theme.json
@@ -43,6 +43,7 @@
     "method": {"fontStyle": "italic"},
     "comment.documentation": {"foreground": "#548759"},
     "parameter.label": {"foreground": "#628a91", "fontStyle": "italic"},
+    "decorator": {"foreground": "#6fcad8", "fontStyle": "italic"},
     "annotation": {"foreground": "#6fcad8", "fontStyle": "italic"},
     "property.annotation": {"foreground": "#6fcad8", "fontStyle": "italic"},
     "property.static": {"foreground": "#bd93d5", "fontStyle": ""},


### PR DESCRIPTION
Husky githooks to apply prettier is unnecessary because vscode settings will force format on save.
Such githook will add everything before commit, which might cause mistakes.
So such githook and husky node dependencies are removed.